### PR TITLE
feat: adds loading indicator to post form submit button

### DIFF
--- a/src/components/Interface/PostForm/FormActions/Submit.js
+++ b/src/components/Interface/PostForm/FormActions/Submit.js
@@ -1,22 +1,41 @@
 import React from 'react'
+import classname from 'classnames'
+import { makeStyles } from '@material-ui/styles'
 import Button from '@material-ui/core/Button'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import styles from './Submit.styles'
+
+const useStyles = makeStyles(styles)
 
 function Submit({
   onClick,
   disabled,
+  submitting,
+  children,
   className,
   'data-test-id': dataTestId
 }) {
+  const classes = useStyles()
+  const rootClasses = classname([classes.root, className])
+
+  const loadingIcon = submitting && (
+    <CircularProgress
+      size={16}
+      data-test-id="post-form-submit-indicator"
+    />
+  )
+
   return (
     <Button
       data-test-id={dataTestId}
       onClick={onClick}
-      disabled={disabled}
-      className={className}
+      disabled={disabled || submitting}
+      className={rootClasses}
       color="secondary"
       variant="outlined"
+      startIcon={loadingIcon}
     >
-      Done
+      {children}
     </Button>
   )
 }

--- a/src/components/Interface/PostForm/FormActions/Submit.styles.js
+++ b/src/components/Interface/PostForm/FormActions/Submit.styles.js
@@ -1,0 +1,10 @@
+const styles = theme => ({
+  root: {
+    '& .MuiButton-label': {
+      display: 'flex',
+      justifyContent: 'space-between'
+    }
+  }
+})
+
+export default styles

--- a/src/components/Interface/PostForm/FormActions/Submit.test.js
+++ b/src/components/Interface/PostForm/FormActions/Submit.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { createMount } from '@material-ui/core/test-utils'
+
+import { withTheme } from '../../../../utils/testing'
+
+import Submit from './Submit'
+
+let mount
+
+const SubmitWithSetup = withTheme(Submit)
+
+const setup = propOverrides => {
+  const props = {
+    submitting: false,
+    disabled: false,
+    'data-test-id': 'post-form-submit',
+    ...propOverrides
+  }
+
+  const wrapper = mount(
+    <SubmitWithSetup {...props}>
+      {props.submitting ?
+        'Submitting...' :
+        'Done'
+      }
+    </SubmitWithSetup>
+  )
+
+  return { wrapper, props }
+}
+
+describe('Post Form - Submit', () => {
+  const buttonSelector = `button[data-test-id="post-form-submit"]`
+
+  beforeAll(() => {
+    mount = createMount()
+  })
+
+  it('displays loading indicator', () => {
+    const { wrapper } = setup({ submitting: true })
+
+    const loadingIndicator = wrapper.find(
+      '[data-test-id="post-form-submit-indicator"]'
+    )
+
+    expect(loadingIndicator.exists()).toBe(true)
+  })
+
+  it('is disabled while form is submitting', () => {
+    const { wrapper } = setup({ submitting: true })
+
+    const button = wrapper.find(buttonSelector)
+
+    expect(button.props().disabled).toBe(true)
+  })
+})

--- a/src/components/Interface/PostForm/PostForm.js
+++ b/src/components/Interface/PostForm/PostForm.js
@@ -7,7 +7,12 @@ import Typography from '@material-ui/core/Typography'
 import BasicInfo from './BasicInfo'
 import ThumbnailSelection from './ThumbnailSelection'
 import ImagesSelection from './ImagesSelection'
-import FormActions, { Back, Next, Submit } from './FormActions'
+import {
+  default as FormActions,
+  Back,
+  Next,
+  Submit
+} from './FormActions'
 import FormErrors from './FormErrors'
 import {
   MIN_STEP,
@@ -16,6 +21,7 @@ import {
   CURRENT_STEP_ROOT,
   STEPS
 } from './PostForm.constants'
+import { useCreatePost } from '../../../hooks'
 
 import styles from './styles'
 
@@ -51,6 +57,9 @@ function PostForm({ onSubmit }) {
   const [ formState, formFieldInitializers ] = (
     useFormState(initialFormValues)
   )
+
+  const { state: createPostState } = useCreatePost()
+  const { submitting: submittingForm } = createPostState
 
   const classes = useStyles()
 
@@ -174,8 +183,14 @@ function PostForm({ onSubmit }) {
   const submitButton = (
     <Submit
       onClick={handleSubmitClick}
-      disabled={submitDisabled}
-    />
+      disabled={submitDisabled || submittingForm}
+      submitting={submittingForm}
+    >
+      {submittingForm ?
+        'Submitting...' :
+        'Done'
+      }
+    </Submit>
   )
 
   const renderCurrentStep = (steps, currentStepIndex) => {


### PR DESCRIPTION
Adds a loading indicator to post form submit button that is displayed while the form is submitting (while a post is being created/updated). Submit button is disabled while form is submitting.