### PR TITLE
fix: fixes existing PostForm tests

### DIFF
--- a/src/components/Interface/PostForm/PostForm.test.js
+++ b/src/components/Interface/PostForm/PostForm.test.js
@@ -2,7 +2,10 @@ import React from 'react'
 import { createMount } from '@material-ui/core/test-utils'
 
 import { withTheme, configureMockStore, withProvider } from '../../../utils/testing'
-import { mockImagesState } from '../../../utils/testing/mocks'
+import {
+  mockImagesState,
+  createMockCreatePostState
+} from '../../../utils/testing/mocks'
 import PostForm, { ROOT_ELEMENT_ID } from './PostForm'
 import {
   MIN_STEP,
@@ -14,10 +17,15 @@ import {
 
 let mount
 
+const mockCreatePostState = createMockCreatePostState()
+
 const PostFormWithSetup = withTheme(
   withProvider(
     PostForm,
-    { images: mockImagesState }
+    {
+      images: mockImagesState,
+      createPost: mockCreatePostState
+    }
   )
 )
 

--- a/src/reducers/create-post/index.js
+++ b/src/reducers/create-post/index.js
@@ -45,3 +45,4 @@ const createPostReducer = (state = initialState, action) => {
 }
 
 export default createPostReducer
+export { initialState }

--- a/src/utils/testing/mocks/createPost.js
+++ b/src/utils/testing/mocks/createPost.js
@@ -1,0 +1,8 @@
+import { initialState } from '../../../reducers/create-post'
+
+const createMockCreatePostState = overrides => ({
+  ...initialState,
+  ...overrides
+})
+
+export { createMockCreatePostState }

--- a/src/utils/testing/mocks/index.js
+++ b/src/utils/testing/mocks/index.js
@@ -1,2 +1,3 @@
 export { mockImagesData, mockImagesState } from './images'
 export { mockPost } from './posts'
+export { createMockCreatePostState } from './createPost'


### PR DESCRIPTION
Fixes existing PostForm tests by mocking createPost state. createPost state is accessed by PostForm component but tests were not updated to accommodate for this when create post integration was done