### PR TITLE
fix: thumbnail image validation check

### DIFF
--- a/src/components/Interface/PostForm/PostForm.js
+++ b/src/components/Interface/PostForm/PostForm.js
@@ -108,15 +108,16 @@ function PostForm({ onSubmit }) {
   const formHasValidationErrors = Object.values(validity).some(value => !value)
   const formTouched = Object.values(touched).some(fieldTouched => fieldTouched)
   const hasAtLeastOneImage = values.images.length > 0
-  const hasThumbnail = values.thumbnailImage
   const requiredFieldHasValue = fieldName => values[fieldName]
   const hasTitle = requiredFieldHasValue('title')
+  const hasThumbnail = requiredFieldHasValue('thumbnailImage')
 
   const submitDisabled = (
     formHasValidationErrors ||
     !formTouched ||
     !hasAtLeastOneImage ||
-    !hasTitle
+    !hasTitle ||
+    !hasThumbnail
   )
 
   const formErrors = [


### PR DESCRIPTION
Fixes issue where selection of thumbnail image was not being considered in validation expression. Form submit button is now disabled if a thumbnail image for a post has not been selected