### PR TITLE
refactor: abstracts truncateText util for reuse

### DIFF
--- a/src/components/Interface/PostsList/PostsListItemContent/PostsListItemContent.js
+++ b/src/components/Interface/PostsList/PostsListItemContent/PostsListItemContent.js
@@ -4,15 +4,9 @@ import Grid from '@material-ui/core/Grid'
 import Avatar from '@material-ui/core/Avatar'
 import Typography from '@material-ui/core/Typography'
 
+import truncateText from '../../../../utils/truncate-text'
+
 function PostsListItemContent({ post }) {
-  const truncateText = maxLength => string => {
-    if (string.length <= maxLength) {
-      return string
-    }
-
-    return `${string.slice(0, maxLength + 1).trim()}...`
-  }
-
   const truncateDescription = truncateText(42)
   const truncateTitle = truncateText(15)
 

--- a/src/utils/truncate-text/index.js
+++ b/src/utils/truncate-text/index.js
@@ -1,0 +1,36 @@
+const truncateText = maxLength => string => {
+  if (!string) {
+    return
+  }
+
+  if (isNaN(maxLength)) {
+    return string
+  }
+
+  if (string.length <= maxLength) {
+    return string
+  }
+
+  const truncatedText = (
+    `${string.slice(0, maxLength).trim()}...`
+  )
+
+  const truncatedTextLengthMatchesSource = (
+    truncatedText.length === string.length
+  )
+
+  const truncatedTextLengthLongerThanSource = (
+    truncatedText.length > string.length
+  )
+
+  if (
+    truncatedTextLengthMatchesSource ||
+    truncatedTextLengthLongerThanSource
+  ) {
+    return string
+  }
+
+  return truncatedText
+}
+
+export default truncateText

--- a/src/utils/truncate-text/index.test.js
+++ b/src/utils/truncate-text/index.test.js
@@ -1,0 +1,51 @@
+import truncateText from '.'
+
+describe('truncateText', () => {
+  it('can truncate text', () => {
+    const text = 'foobarbaz'
+    const maxLength = 3
+
+    const expected = 'foo...'
+    const actual = truncateText(maxLength)(text)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('uses source string if result length === maxLength', () => {
+    const text = 'foobar'
+    const maxLength = 3
+
+    const expected = text
+    const actual = truncateText(maxLength)(text)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('uses source string if result length > maxLength', () => {
+    const text = 'foobar'
+    const maxLength = 5
+
+    const expected = text
+    const actual = truncateText(maxLength)(text)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('does not throw if string is undefined', () => {
+    const maxLength = 5
+
+    const expected = undefined
+    const actual = truncateText(maxLength)()
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('does not throw if maxLength arg is undefined', () => {
+    const text = 'foo'
+
+    const expected = text
+    const actual = truncateText()(text)
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Abstracts truncateText utility created in PostListItemContent component into utils directory to make the utility available for reuse across the application. Adds tests to verify utility functionality.