### PR TITLE
feat: show loading indicator when getting posts

### DIFF
--- a/src/components/Interface/PostsList/PostsList.js
+++ b/src/components/Interface/PostsList/PostsList.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
+import LinearProgress from '@material-ui/core/LinearProgress'
 import Grid from '@material-ui/core/Grid'
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -19,7 +20,10 @@ function PostsList() {
     actions
   } = usePosts()
 
-  const { data: postsData } = state
+  const {
+    data: postsData,
+    retrievingPosts
+  } = state
   const { getPosts, viewPost } = actions
 
   useEffect(() => {
@@ -31,24 +35,31 @@ function PostsList() {
   }
 
   return (
-    <List>
-      {postsData.map(post =>
-        <ListItem
-          key={post._id}
-          className={classes.listItem}
-          onClick={() => onListItemClick(post)}
-        >
-          <Grid container alignItems="center">
-            <Grid item xs={9}>
-              <PostsListItemContent post={post} />
-            </Grid>
-            <Grid item xs={3}>
-              <PostsListItemActions />
-            </Grid>
-          </Grid>
-        </ListItem>
-      )}
-    </List>
+    <>
+      {retrievingPosts &&
+        <LinearProgress color="secondary" />
+      }
+      {!retrievingPosts &&
+        <List>
+          {postsData.map(post =>
+            <ListItem
+              key={post._id}
+              className={classes.listItem}
+              onClick={() => onListItemClick(post)}
+            >
+              <Grid container alignItems="center">
+                <Grid item xs={9}>
+                  <PostsListItemContent post={post} />
+                </Grid>
+                <Grid item xs={3}>
+                  <PostsListItemActions />
+                </Grid>
+              </Grid>
+            </ListItem>
+          )}
+        </List>
+      }
+    </>
   )
 }
 

--- a/src/components/Interface/PostsList/PostsList.test.js
+++ b/src/components/Interface/PostsList/PostsList.test.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { createMount } from '@material-ui/core/test-utils'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+
+import { withTheme, configureMockStore, withProvider } from '../../../utils/testing'
+import { createMockPostsState, mockPosts } from '../../../utils/testing/mocks'
+
+import PostsList from './PostsList'
+
+let mount
+
+const getMockState = overrides => (
+  createMockPostsState(overrides)
+)
+
+const configComponent = mockState => (
+  withTheme(
+    withProvider(
+      PostsList,
+      mockState
+    )
+  )
+)
+
+const setup = mockState => propOverrides => {
+  const props = { ...propOverrides }
+
+  configureMockStore(mockState)
+  const Component = configComponent(mockState)
+
+  const wrapper = mount(
+    <Component {...props} />
+  )
+
+  return { wrapper, props }
+}
+
+describe('PostsList', () => {
+  beforeAll(() => {
+    mount = createMount()
+  })
+
+  it('displays posts list', () => {
+    const mockState = getMockState({
+      data: mockPosts
+    })
+
+    const { wrapper } = setup({ posts: mockState })()
+
+    const postsList = wrapper.find(List)
+    const postsListItems = wrapper.find(ListItem)
+
+    expect(postsList.exists()).toBe(true)
+    expect(postsListItems.exists()).toBe(true)
+    expect(postsListItems.length).toEqual(mockPosts.length)
+  })
+
+  it('displays loading indicator when retrieving posts', () => {
+    const mockState = getMockState({
+      retrievingPosts: true
+    })
+
+    const { wrapper } = setup({ posts: mockState })()
+
+    const loadingIndicator = wrapper.find(LinearProgress)
+
+    expect(loadingIndicator.exists()).toBe(true)
+  })
+})

--- a/src/reducers/posts/index.js
+++ b/src/reducers/posts/index.js
@@ -33,3 +33,4 @@ const postsReducer = (state = initialState, action) => {
 }
 
 export default postsReducer
+export { initialState }

--- a/src/utils/testing/mocks/index.js
+++ b/src/utils/testing/mocks/index.js
@@ -1,3 +1,3 @@
 export { mockImagesData, mockImagesState } from './images'
-export { mockPost, mockPosts } from './posts'
+export { mockPost, mockPosts, createMockPostsState } from './posts'
 export { createMockCreatePostState } from './createPost'

--- a/src/utils/testing/mocks/posts.js
+++ b/src/utils/testing/mocks/posts.js
@@ -1,3 +1,5 @@
+import { initialState } from '../../../reducers/posts'
+
 const mockPost = { title: 'mock' }
 
 const mockPosts = [
@@ -30,4 +32,9 @@ const mockPosts = [
   }
 ]
 
-export { mockPost, mockPosts }
+const createMockPostsState = overrides => ({
+  ...initialState,
+  ...overrides
+})
+
+export { mockPost, mockPosts, createMockPostsState }


### PR DESCRIPTION
Displays a loading indicator in PostsList component when posts are being retrieved from API. Note that it is up to the consumer of PostsList component to create an adequate containing component that properly lays out (e.g., horizontal & vertical centering) the content (loading indicator/actual list) rendered by PostsList component. Includes unit tests.