### PR TITLE
feat: allow post form to by "hydrated"

### DIFF
--- a/src/components/Interface/PostForm/PostForm.js
+++ b/src/components/Interface/PostForm/PostForm.js
@@ -41,21 +41,46 @@ const canDecrementStep = (currentStep, minStep) => (
   decrementStep(currentStep) >= minStep
 )
 
-const initialFormValues = {
-  title: '',
-  description: '',
-  embedContent: '',
-  featured: false,
-  thumbnailImage: '',
-  images: []
+const generateInitialFormValues = post => {
+  const defaultValues = {
+    title: '',
+    description: '',
+    embedContent: '',
+    featured: false,
+    thumbnailImage: '',
+    images: []
+  }
+
+  if (!post) {
+    return defaultValues
+  }
+
+  const {
+    title,
+    description,
+    embedContent,
+    featured,
+    thumbnailImage,
+    images
+  } = post
+
+  return {
+    ...defaultValues,
+    title,
+    description,
+    embedContent,
+    featured,
+    thumbnailImage,
+    images
+  }
 }
 
 const ROOT_ELEMENT_ID = 'pf'
 
-function PostForm({ onSubmit }) {
+function PostForm({ onSubmit, post }) {
   const [ currentStep, setCurrentStep ] = useState(1)
   const [ formState, formFieldInitializers ] = (
-    useFormState(initialFormValues)
+    useFormState(generateInitialFormValues(post))
   )
 
   const { state: createPostState } = useCreatePost()
@@ -234,4 +259,9 @@ function PostForm({ onSubmit }) {
 }
 
 export default PostForm
-export { ROOT_ELEMENT_ID, MAX_STEP, MIN_STEP }
+export {
+  ROOT_ELEMENT_ID,
+  MAX_STEP,
+  MIN_STEP,
+  generateInitialFormValues
+}

--- a/src/components/Interface/PostForm/PostForm.test.js
+++ b/src/components/Interface/PostForm/PostForm.test.js
@@ -6,7 +6,10 @@ import {
   mockImagesState,
   createMockCreatePostState
 } from '../../../utils/testing/mocks'
-import PostForm, { ROOT_ELEMENT_ID } from './PostForm'
+import PostForm, {
+  ROOT_ELEMENT_ID,
+  generateInitialFormValues
+} from './PostForm'
 import {
   MIN_STEP,
   MAX_STEP,
@@ -120,5 +123,44 @@ describe('Post Form', () => {
 
   it('renders images select step', () => {
     stepRenderingTester(STEP_IDS.POST_IMAGES)
+  })
+
+  it('generates initial default form values', () => {
+    const expectedInitialValues = {
+      title: '',
+      description: '',
+      embedContent: '',
+      images: [],
+      thumbnailImage: '',
+      featured: false
+    }
+
+    const actualInitialValues = generateInitialFormValues()
+
+    expect(actualInitialValues).toEqual(expectedInitialValues)
+  })
+
+  it('generates initial prefilled values from post', () => {
+    const post = {
+      title: 'some-title',
+      description: 'some description',
+      embedContent: '',
+      images: ['foo.jpg'],
+      thumbnailImage: 'bar.jpg',
+      featured: true
+    }
+
+    const expectedInitialValues = {
+      title: 'some-title',
+      description: 'some description',
+      embedContent: '',
+      images: ['foo.jpg'],
+      thumbnailImage: 'bar.jpg',
+      featured: true
+    }
+
+    const actualInitialValues = generateInitialFormValues(post)
+
+    expect(actualInitialValues).toEqual(expectedInitialValues)
   })
 })


### PR DESCRIPTION
Allows post form to be prefilled with existing values (post editing)