### PR TITLE
feat: query string constructor function

### DIFF
--- a/src/services/utils/construct-query-string/index.js
+++ b/src/services/utils/construct-query-string/index.js
@@ -1,0 +1,46 @@
+/**
+ * Constructs a URL query string based on query object and
+ * acceptedProperties array.
+ * @param {string[]} acceptedProperties - Each item is an
+ * accepted query params property
+ * @return {() => query: object => string) - Function that
+ * takes query object as a parameter and returns final
+ * query string
+ */
+const constructQueryString = acceptedProperties => query => {
+  if (!query) {
+    return ''
+  }
+
+  const queryEmpty = Object.keys(query).length === 0
+  if (queryEmpty) {
+    return ''
+  }
+
+  const queryParamValid = property => {
+    if (!acceptedProperties) {
+      // all param properties are considered to be valid
+      // if acceptedProperties object value is falsy
+      return true
+    }
+
+    return acceptedProperties.includes(property)
+  }
+
+  const KEY = 0
+  const VALUE = 1
+
+  const queryStringsArray = (
+    Object.entries(query).map(keyValueTuple => (
+      queryParamValid(keyValueTuple[KEY]) ? (
+        `${keyValueTuple[KEY]}=${keyValueTuple[VALUE]}`
+      ) : null
+    )).filter(paramString => paramString)
+  )
+
+  const queryString = `?${queryStringsArray.join('&')}`
+
+  return queryString
+}
+
+export default constructQueryString

--- a/src/services/utils/construct-query-string/index.test.js
+++ b/src/services/utils/construct-query-string/index.test.js
@@ -1,0 +1,46 @@
+import constructQueryString from '.'
+
+describe('constructQueryString', () => {
+  it('returns empty string when args undefined', () => {
+    const expected = ''
+    const actual = constructQueryString()()
+
+    expect(actual).toBe(expected)
+  })
+
+  it('returns empty string when query object is empty', () => {
+    const expected = ''
+    const actual = constructQueryString()({})
+
+    expect(actual).toBe(expected)
+  })
+
+  it('can construct a valid query string', () => {
+    const expected = '?foo=bar&baz=foobar'
+    const query = {
+      foo: 'bar',
+      baz: 'foobar'
+    }
+
+    const actual = constructQueryString()(query)
+
+    expect(actual).toBe(expected)
+  })
+
+  it('ignores unaccepted properties', () => {
+    const expected = '?foo=bar'
+    const query = {
+      foo: 'bar',
+      baz: 'foobar',
+      test: 'testing'
+    }
+
+    const acceptedProperties = ['foo']
+
+    const actual = constructQueryString(
+      acceptedProperties
+    )(query)
+
+    expect(actual).toBe(expected)
+  })
+})


### PR DESCRIPTION
Curried utility function that allows consumer to specify a property of accepted objects and query object to construct a URL query params string.