### PR TITLE
Task/edit post route

### DIFF
--- a/src/routes/Interface/Content/EditPost/EditPost.js
+++ b/src/routes/Interface/Content/EditPost/EditPost.js
@@ -1,12 +1,39 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Typography from '@material-ui/core/Typography'
 
+import PostForm from '../../../../components/Interface/PostForm'
+
+import { usePosts, useImagesActions } from '../../../../hooks'
+
 function EditPost(props) {
+  const { match } = props
+  const { id } = match.params
+
+  const { getImagesRoutine } = useImagesActions()
+  const { actions, state } = usePosts()
+  const { getPosts } = actions
+  const { data: posts, retrievingPosts } = state
+
+  const postToEdit = posts.find(post => post._id === id)
+
+  useEffect(() => {
+    getImagesRoutine()
+  }, [getImagesRoutine])
+
+  useEffect(() => {
+    getPosts({
+      query: { id }
+    })
+  }, [id])
+
   return (
     <div>
-      <Typography variant="h3">
+      <Typography variant="h4" gutterBottom>
         Edit Post
       </Typography>
+      {!retrievingPosts && postToEdit &&
+        <PostForm post={postToEdit} />
+      }
     </div>
   )
 }

--- a/src/routes/Interface/Content/EditPost/EditPost.js
+++ b/src/routes/Interface/Content/EditPost/EditPost.js
@@ -1,11 +1,18 @@
 import React, { useEffect } from 'react'
 import Typography from '@material-ui/core/Typography'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { makeStyles } from '@material-ui/core/styles'
 
 import PostForm from '../../../../components/Interface/PostForm'
 
 import { usePosts, useImagesActions } from '../../../../hooks'
 
+import styles from './styles'
+
+const useStyles = makeStyles(styles)
+
 function EditPost(props) {
+  const classes = useStyles()
   const { match } = props
   const { id } = match.params
 
@@ -31,9 +38,16 @@ function EditPost(props) {
       <Typography variant="h4" gutterBottom>
         Edit Post
       </Typography>
-      {!retrievingPosts && postToEdit &&
-        <PostForm post={postToEdit} />
-      }
+      <div className={classes.contentRoot}>
+        {!retrievingPosts && postToEdit &&
+          <div className={classes.form}>
+            <PostForm post={postToEdit} />
+          </div>
+        }
+        {retrievingPosts &&
+          <CircularProgress color="secondary" />
+        }
+      </div>
     </div>
   )
 }

--- a/src/routes/Interface/Content/EditPost/EditPost.js
+++ b/src/routes/Interface/Content/EditPost/EditPost.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Typography from '@material-ui/core/Typography'
+
+function EditPost(props) {
+  return (
+    <div>
+      <Typography variant="h3">
+        Edit Post
+      </Typography>
+    </div>
+  )
+}
+
+export default EditPost

--- a/src/routes/Interface/Content/EditPost/EditPost.js
+++ b/src/routes/Interface/Content/EditPost/EditPost.js
@@ -4,6 +4,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import { makeStyles } from '@material-ui/core/styles'
 
 import PostForm from '../../../../components/Interface/PostForm'
+import PostNotFoundNotice from './PostNotFoundNotice'
 
 import { usePosts, useImagesActions } from '../../../../hooks'
 
@@ -46,6 +47,9 @@ function EditPost(props) {
         }
         {retrievingPosts &&
           <CircularProgress color="secondary" />
+        }
+        {!retrievingPosts && !postToEdit &&
+          <PostNotFoundNotice />
         }
       </div>
     </div>

--- a/src/routes/Interface/Content/EditPost/EditPost.test.js
+++ b/src/routes/Interface/Content/EditPost/EditPost.test.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { createMount } from '@material-ui/core/test-utils'
+
+import {
+  withTheme,
+  configureMockStore,
+  withProvider
+} from '../../../../utils/testing'
+import {
+  createMockPostsState,
+  mockPosts
+} from '../../../../utils/testing/mocks'
+import EditPost from './EditPost'
+import PostForm from '../../../../components/Interface/PostForm'
+import PostNotFoundNotice from './PostNotFoundNotice'
+
+let mount
+
+const configComponent = mockState => (
+  withTheme(
+    withProvider(
+      EditPost,
+      mockState
+    )
+  )
+)
+
+const setup = mockState => propOverrides => {
+  const props = {
+    ...propOverrides
+  }
+
+  configureMockStore(mockState)
+  const Component = configComponent(mockState)
+
+  const wrapper = mount(
+    <MemoryRouter initialEntries={['/edit-post/1']}>
+      <Route
+        component={props => <Component {...props} />}
+        path="/edit-post/:id"
+      />
+    </MemoryRouter>
+  )
+
+  return { wrapper, props }
+}
+
+describe('EditPost', () => {
+  beforeAll(() => {
+    mount = createMount()
+  })
+
+  it('displays loading indicator when retrieving post', () => {
+    const mockState = createMockPostsState({
+      retrievingPosts: true,
+      data: []
+    })
+
+    const { wrapper } = setup({ posts: mockState })()
+
+    const notice = wrapper.find(PostNotFoundNotice)
+    const loadingIndicator = wrapper.find(CircularProgress)
+    const form = wrapper.find(PostForm)
+
+    expect(notice.exists()).toBe(false)
+    expect(loadingIndicator.exists()).toBe(true)
+    expect(form.exists()).toBe(false)
+  })
+
+  it('displays post form when post has been retrieved', () => {
+    const mockState = createMockPostsState({
+      data: mockPosts
+    })
+
+    const { wrapper } = setup({
+      posts: mockState,
+      createPost: {}
+    })()
+
+    const notice = wrapper.find(PostNotFoundNotice)
+    const loadingIndicator = wrapper.find(CircularProgress)
+    const form = wrapper.find(PostForm)
+    expect(notice.exists()).toBe(false)
+    expect(loadingIndicator.exists()).toBe(false)
+    expect(form.exists()).toBe(true)
+  })
+
+  it('displays notice when post not found', () => {
+    const mockState = createMockPostsState()
+
+    const { wrapper } = setup({
+      posts: mockState
+    })()
+
+    const notice = wrapper.find(PostNotFoundNotice)
+    const loadingIndicator = wrapper.find(CircularProgress)
+    const form = wrapper.find(PostForm)
+    expect(notice.exists()).toBe(true)
+    expect(loadingIndicator.exists()).toBe(false)
+    expect(form.exists()).toBe(false)
+  })
+})

--- a/src/routes/Interface/Content/EditPost/PostNotFoundNotice/PostNotFoundNotice.js
+++ b/src/routes/Interface/Content/EditPost/PostNotFoundNotice/PostNotFoundNotice.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import { makeStyles } from '@material-ui/core/styles'
+import { Link } from 'react-router-dom'
+
+import { ROUTES } from '../../../../routes.constants'
+
+import styles from './styles'
+
+const { INTERFACE_ROUTES } = ROUTES
+const { HOME } = INTERFACE_ROUTES
+
+const useStyles = makeStyles(styles)
+
+function PostNotFoundNotice() {
+  const classes = useStyles()
+
+  return (
+    <div className={classes.root}>
+      <Typography
+        variant="h5"
+        gutterBottom
+        className={classes.text}
+      >
+        Post to edit was not found
+      </Typography>
+      <Link to={HOME} className={classes.link}>
+        <Button color="secondary">
+          Go to Dashboard
+        </Button>
+      </Link>
+    </div>
+  )
+}
+
+export default PostNotFoundNotice

--- a/src/routes/Interface/Content/EditPost/PostNotFoundNotice/index.js
+++ b/src/routes/Interface/Content/EditPost/PostNotFoundNotice/index.js
@@ -1,0 +1,1 @@
+export { default } from './PostNotFoundNotice'

--- a/src/routes/Interface/Content/EditPost/PostNotFoundNotice/styles.js
+++ b/src/routes/Interface/Content/EditPost/PostNotFoundNotice/styles.js
@@ -1,0 +1,13 @@
+const styles = theme => ({
+  root: {
+    textAlign: 'center'
+  },
+  text: {
+    marginBottom: theme.spacing(10)
+  },
+  link: {
+    color: 'transparent'
+  }
+})
+
+export default styles

--- a/src/routes/Interface/Content/EditPost/index.js
+++ b/src/routes/Interface/Content/EditPost/index.js
@@ -1,0 +1,1 @@
+export { default } from './EditPost'

--- a/src/routes/Interface/Content/EditPost/styles.js
+++ b/src/routes/Interface/Content/EditPost/styles.js
@@ -1,0 +1,13 @@
+const styles = theme => ({
+  contentRoot: {
+    minHeight: theme.spacing(40),
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  form: {
+    width: '100%'
+  }
+})
+
+export default styles

--- a/src/routes/Interface/Content/index.js
+++ b/src/routes/Interface/Content/index.js
@@ -7,6 +7,7 @@ import ViewPost from './ViewPost'
 import Images from './Images'
 import UploadImages from './UploadImages'
 import CreatePost from './CreatePost'
+import EditPost from './EditPost'
 import { ROUTES } from '../../routes.constants'
 
 import './index.css'
@@ -16,6 +17,7 @@ const {
   HOME: INTERFACE_HOME,
   CREATE_POST,
   VIEW_POST,
+  EDIT_POST,
   IMAGES,
   UPLOAD_IMAGES
 } = INTERFACE_ROUTES
@@ -25,6 +27,7 @@ const Content = ({ match, posts }) => (
     <Route exact path={`${match.url}/${INTERFACE_HOME}`} component={Dashboard} />
     <Route exact path={`${match.url}/${CREATE_POST}`} component={CreatePost} />
     <Route path={`${match.url}/${VIEW_POST}/:id`} component={ViewPost} />
+    <Route path={`${match.url}/${EDIT_POST}/:id`} component={EditPost} />
     <Route exact path={`${match.url}/${IMAGES}`} component={Images} />
     <Route path={`${match.url}/${UPLOAD_IMAGES}`} component={UploadImages} />
   </Container>

--- a/src/routes/routes.constants.js
+++ b/src/routes/routes.constants.js
@@ -6,6 +6,7 @@ const ROUTES = {
     HOME: '',
     CREATE_POST: 'create-post',
     VIEW_POST: 'view-post',
+    EDIT_POST: 'edit-post',
     IMAGES: 'images',
     UPLOAD_IMAGES: 'images/upload'
   }

--- a/src/sagas/get-posts/index.js
+++ b/src/sagas/get-posts/index.js
@@ -9,7 +9,7 @@ function* handleGetPosts(action) {
   try {
     const result = yield call(
       postsService.getPosts,
-      payload
+      payload || {}
     )
 
     yield put(

--- a/src/services/posts/index.js
+++ b/src/services/posts/index.js
@@ -1,6 +1,9 @@
 import axios from 'axios'
 
-import { handleAxiosRequestError } from '../utils'
+import {
+  handleAxiosRequestError,
+  constructQueryString
+} from '../utils'
 
 const API_URL = process.env.REACT_APP_API_URL
 
@@ -34,9 +37,19 @@ const createPost = data => {
 
 /**
  * Fires a network request to API to retrieve posts
+ * @param {object} options - Contains various request-related
+ * configuration options (such as request query params)
  * @return {Promise<object>} - API response data
  */
-const getPosts = () => {
+const getPosts = (options) => {
+  const validQueryProperties = ['id']
+  const constructPostsQueryString = (
+    constructQueryString(validQueryProperties)
+  )
+
+  const { query } = options
+  const queryString = constructPostsQueryString(query)
+  const url = `${API_URL}/posts${queryString}`
   const authToken = localStorage.getItem('jr-site-auth-token')
 
   const requestOptions = {
@@ -44,7 +57,7 @@ const getPosts = () => {
     headers: {
       'Authorization': `Bearer: ${authToken}`
     },
-    url: `${API_URL}/posts`
+    url
   }
 
   return axios(requestOptions)

--- a/src/services/utils/index.js
+++ b/src/services/utils/index.js
@@ -1,3 +1,5 @@
+import constructQueryString from './construct-query-string'
+
 const handleAxiosRequestError = (error) => {
   if (error.response) {
     // The request was made and the server responded with a
@@ -13,5 +15,6 @@ const handleAxiosRequestError = (error) => {
 }
 
 export {
-  handleAxiosRequestError
+  handleAxiosRequestError,
+  constructQueryString
 }

--- a/src/utils/testing/mocks/posts.js
+++ b/src/utils/testing/mocks/posts.js
@@ -4,7 +4,7 @@ const mockPost = { title: 'mock' }
 
 const mockPosts = [
   {
-    _id: 1,
+    _id: '1',
     title: 'Quintacolor',
     description: "QUINTACOLOR is a simple yet inspiring browser game. I found it's developer, Tom Quinn through Reddits 'I Need A Team' (INAT) subreddit, who then brought me on to compose music, produce SFX, and mix audio.",
     created: new Date('2018-05-14T22:03:42'),
@@ -13,7 +13,7 @@ const mockPosts = [
     images: ['http://jruttenberg.io/images/posts/1WdT4tBS9iyx/5142018100455-jz2kBZV-asdf.png']
   },
   {
-    _id: 2,
+    _id: '2',
     title: 'Stormwind Theme Song But Every Note is Leeroy Jenkins',
     description: 'What would happen if you took the most recognizable music from World of Warcraft and replaced all the instruments with the most recognizable meme from World of Warcraft?',
     created: new Date('2018-03-20T21:25:04.414Z'),
@@ -22,7 +22,7 @@ const mockPosts = [
     images: ['http://jruttenberg.io/images/posts/JL7JkuKA5lVz/320201892504-3PyaZWx-500x500Stormwind-Leeroy.png']
   },
   {
-    _id: 3,
+    _id: '3',
     title: 'Story Sounds 1 - Water',
     description: '"Story Sounds 1 - Water" is the first of many audio sample packs that are meant to bolster the immersion and storytelling capabilities of digital media like video games. All of these samples were recorded in Iceland in February of 2018. Soon they will be available for purchase on the Unity and Unreal Asset Stores.',
     created: new Date('2018-02-27T15:59:49.041Z'),


### PR DESCRIPTION
Adds route for editing a post.  When you go to `/edit-post/:id` route, the route component will use the `id` url param to retrieve the post to edit from the API. The form is "hydrated" with the retrieved post's data. If no post is found, a notice is displayed that gives the user an option to navigate to dashboard.