### PR TITLE
fix: prefilled form validation

### DIFF
--- a/src/components/Interface/PostForm/PostForm.js
+++ b/src/components/Interface/PostForm/PostForm.js
@@ -134,6 +134,7 @@ function PostForm({ onSubmit, post }) {
 
   const formHasValidationErrors = Object.values(validity).some(value => !value)
   const formTouched = Object.values(touched).some(fieldTouched => fieldTouched)
+  const formPrefilled = !!post
   const hasAtLeastOneImage = values.images.length > 0
   const requiredFieldHasValue = fieldName => values[fieldName]
   const hasTitle = requiredFieldHasValue('title')
@@ -141,7 +142,7 @@ function PostForm({ onSubmit, post }) {
 
   const submitDisabled = (
     formHasValidationErrors ||
-    !formTouched ||
+    (!formTouched && !formPrefilled) ||
     !hasAtLeastOneImage ||
     !hasTitle ||
     !hasThumbnail


### PR DESCRIPTION
Fixes issue where a prefilled form would not be considered valid if none of the form fields had been touched. Adds logic to override form touched check if form has been prefilled.