### PR TITLE
fix: rework delete post dialog so post data doesn't disappear

### DIFF
--- a/src/components/Interface/DeletePostDialog/DeletePostDialog.js
+++ b/src/components/Interface/DeletePostDialog/DeletePostDialog.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import Dialog from '@material-ui/core/Dialog'
 import DialogContent from '@material-ui/core/DialogContent'
@@ -11,19 +11,24 @@ import { deletePostRoutine } from '../../../actions'
 
 function DeletePostDialog({
   post,
-  open,
-  onCancel,
-  onConfirm: _onConfirm
+  onAction: _onAction
 }) {
+  const [ actionTaken, setActionTaken ] = useState(false)
   const dispatch = useDispatch()
 
-  const onConfirm = useCallback(() => {
-    _onConfirm && _onConfirm()
-    dispatch(deletePostRoutine(post._id))
+  const onAction = useCallback(action => {
+    setActionTaken(true)
+
+    if (action === 'confirm') {
+      dispatch(deletePostRoutine(post._id))
+    }
   }, [dispatch, deletePostRoutine, post])
 
   return (
-    <Dialog open={open}>
+    <Dialog
+      open={!actionTaken}
+      onExited={_onAction}
+    >
       <DialogTitle>
         Delete &quot;{post && post.title}&quot;
       </DialogTitle>
@@ -36,10 +41,10 @@ function DeletePostDialog({
         </Typography>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>
+        <Button onClick={() => onAction('cancel')}>
           Cancel
         </Button>
-        <Button onClick={onConfirm}>
+        <Button onClick={() => onAction('confirm')}>
           Delete Post
         </Button>
       </DialogActions>

--- a/src/components/Interface/DeletePostDialog/DeletePostDialog.test.js
+++ b/src/components/Interface/DeletePostDialog/DeletePostDialog.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { createMount } from '@material-ui/core/test-utils'
 import DialogTitle from '@material-ui/core/DialogTitle'
-import DialogActions from '@material-ui/core/DialogActions'
 import Typography from '@material-ui/core/Typography'
 
 import {
@@ -76,22 +75,5 @@ describe('DeletePostDialog', () => {
       dialogTitleElement.text().includes(mockPostTitle)
     )
     expect(hasTitle).toBe(true)
-  })
-
-  it('invokes onCancel function prop', () => {
-    const onCancel = jest.fn()
-    const props = {
-      post: mockPost,
-      open: true,
-      onCancel
-    }
-
-    const { wrapper } = setup({ deletePost: mockState })(props)
-
-    const buttons = wrapper.find(DialogActions).find('button')
-    const cancelButton = buttons.at(0)
-    cancelButton.simulate('click')
-
-    expect(onCancel.mock.calls.length).toBe(1)
   })
 })

--- a/src/components/Interface/PostsList/PostsList.js
+++ b/src/components/Interface/PostsList/PostsList.js
@@ -78,12 +78,12 @@ function PostsList() {
           </NoPostsNotice.Action>
         </NoPostsNotice>
       }
-      <DeletePostDialog
-        open={!!postToDelete}
-        post={postToDelete}
-        onCancel={() => setPostToDelete(null)}
-        onConfirm={() => setPostToDelete(null)}
-      />
+      {postToDelete &&
+        <DeletePostDialog
+          post={postToDelete}
+          onAction={() => setPostToDelete(null)}
+        />
+      }
     </div>
   )
 }


### PR DESCRIPTION
Reworks delete post dialog to ensure that post data does not disappear while the dialog is still exiting.